### PR TITLE
adding type construct to help front end be able to develop without having it fully functioning yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ The Lynnwood Food Bank currently serves over 4,000 households and 17,400 individ
 
 [See our living document for more about our project.](https://docs.google.com/document/d/14ZCmqzvU7z0FwthmpE_hgo6zpr88JpUWLSTOOTxHNHk/edit?usp=sharing)
 
+
+## Client Intake
+
+Clients can be intaken using this form here: https://docs.google.com/forms/d/e/1FAIpQLSfVYKqAYVBPiMxV9BJ9w2ZPpfeaxsHHF6lIUMbLH_WcyGvC9Q/viewform
+
+For demoing purposes, please note that the form is not currently connected to the database (almost there), but the UI is finalized
+
+
+
+## Developers Manual
+
 ## Tools
 The only requirement for this project is to have [Node.js](https://nodejs.org/en/download) installed. Instructions can be found in the link. Our project uses version 11.3.0 and has no guarantees for other versions, though higher versions should work. Instructions on how to install dependencies are under [Usage](#Usage)
 

--- a/server/src/intake_forms/custom_types.ts
+++ b/server/src/intake_forms/custom_types.ts
@@ -1,3 +1,4 @@
+import { FBMGuest } from "../../routes/helper";
 export type Clients = Set<Map<string, string | null>>;
 export type Client = Map<string, string | null>;
 
@@ -78,3 +79,17 @@ export const requiredFields = [
     'Head of Household Zip code:',
     'Other than the Head of Household, how many people in their/your household?'
 ];
+
+/**
+ * @fields_invalid is a set of field names that are invalid, basically means the form messed up
+ * @FBMGuest will have '\0' for keys which are required but not present
+ * @fields_erroneous_n_description is a map of field name to description of the error, 
+ *     could be empty or more than one this may have unrequired fields, 
+ *     but only fields that have data. Perhaps have volunteers decide to discard invalid fields
+ *     note: description is for developer, will be subject to change
+ */
+export type Erroneous = {
+    FBMGuest: FBMGuest;
+    fields_invalid: Set<string>;
+    fields_erroneous_n_description: Map<string, string>;
+};

--- a/server/src/intake_forms/flagger.ts
+++ b/server/src/intake_forms/flagger.ts
@@ -3,7 +3,6 @@
 // //import { saveFlagRecord } from './flagRecordService'; // Assume this saves flag records to your server
 // //import { sendToFBM } from './fbmService'; // Assume this sends clients to FBM
 
-// type Erroneous = { FBMGuest: FBMGuest; fields_erroneous: string[] };
 
 // /**simply check to see if required fields are there
 //  * @param {Client} client - The client to be checked.


### PR DESCRIPTION
/**
 * @fields_invalid is a set of field names that are invalid, basically means the form messed up
 * @FBMGuest will have '\0' for keys which are required but not present
 * @fields_erroneous_n_description is a map of field name to description of the error, 
 *     could be empty or more than one this may have unrequired fields, 
 *     but only fields that have data. Perhaps have volunteers decide to discard invalid fields
 *     note: description is for developer, will be subject to change
 */
export type Erroneous = {
    FBMGuest: FBMGuest;
    fields_invalid: Set<string>;
    fields_erroneous_n_description: Map<string, string>;
};

Made some slight changes as i realize may as well just use a map to store the fields. (And you can just do get keys)