### PR TITLE
added a timestamp parameter for erroneous to make it easy to maintain…

### DIFF
--- a/server/__test__/flagger.test.ts
+++ b/server/__test__/flagger.test.ts
@@ -1,8 +1,9 @@
-import { _allRequiredFieldsThere, _checkTrueHouseholdSize, _requiredFieldsToFBM, isHeadOfHouseholdMember, isMemberMissingImportantField, isValidAcknowledgment, isValidAllergies, isValidApartment, isValidBabyFood, isValidBabyFormula, isValidBabyServices, isValidCatFood, isValidCity, isValidCounty, isValidDateOfBirth, isValidDiaperSize, isValidDietaryInformation, isValidDogFood, isValidEthnicFoodPreference, isValidFirstName, isValidFoodModification, isValidHouseholdMembers, isValidHouseholdSize, isValidHouseNumber, isValidLastName, isValidLifeThreateningAllergy, isValidMeatPreference, isValidMemberAge, isValidMemberFirstName, isValidMemberLastName, isValidStreet, isValidTimestamp, isValidZipCode } from '../src/intake_forms/flagger';
+import { _allRequiredFieldsThere, _checkTrueHouseholdSize, _requiredFieldsToFBM, isHeadOfHouseholdMember, isMemberMissingImportantField, isValidAcknowledgment, isValidAllergies, isValidApartment, isValidBabyFood, isValidBabyFormula, isValidBabyServices, isValidCatFood, isValidCity, isValidCounty, isValidDateOfBirth, isValidDiaperSize, isValidDietaryInformation, isValidDogFood, isValidEthnicFoodPreference, isValidFirstName, isValidFoodModification, isValidHouseholdMembers, isValidHouseholdSize, isValidHouseNumber, isValidLastName, isValidLifeThreateningAllergy, isValidMeatPreference, isValidMemberAge, isValidMemberFirstName, isValidMemberLastName, isValidStreet, isValidTimestamp, isValidZipCode, toISOFormat } from '../src/intake_forms/flagger';
 import { copyErroneous, emptyErroneous, emptyFBMGuest, fieldMap, requiredFields } from '../src/intake_forms/custom_types';
 import { mockClientComplete, mockClientMissingSomeRequiredNull, mockClientSomeRequiredEmpty, mockClientMissingAllRequiredNull, mockClientMissingAllRequiredEmptyString, mockClientMissingAllRequiredUndefined, onlyHeadOfHousehold, mockClientMissingOneRequiredNull } from './mock_clients';
 import { Erroneous, Client } from '../src/intake_forms/custom_types';
 import { FBMGuest } from '../routes/helper';
+import { time } from 'console';
 function createClient(fields: Record<string, any>): Map<string, any> {
     return new Map(Object.entries(fields));
 }
@@ -537,18 +538,31 @@ describe.each([
             invalid: true,
         }
     }
+
+
 ])('isValidTimestamp - $name', ({ timestamp, inputErroneousFields, expectedInvalid, expectedDescriptions, expectedFlags }) => {
+    const erroneousFields = isValidTimestamp(timestamp, inputErroneousFields);
     it('produces correct erroneous fields and flags', () => {
-        const erroneousFields = isValidTimestamp(timestamp, inputErroneousFields);
+
 
         expect(Array.from(erroneousFields.fields_invalid)).toEqual(Array.from(expectedInvalid));
         expect(erroneousFields.fields_erroneous_n_description.size).toBe(expectedDescriptions.size);
         expectedInvalid.forEach((field) => {
             expect(erroneousFields.fields_erroneous_n_description.get(field)).not.toBeNull();
         });
-
         expect(erroneousFields.flags.invalid).toBe(expectedFlags.invalid);
         expect(erroneousFields.FBMGuest).toEqual(inputErroneousFields.FBMGuest); // Ensure FBMGuest is preserved
+    });
+    it('UTC error for test', () => {
+        if (!expectedFlags.invalid) {
+            if (!timestamp) {
+                throw new Error('Timestamp is undefined, cannot parse.');
+            }
+            const expectedUTCTime: number = Date.parse(timestamp);
+            if (expectedUTCTime) {
+                expect(erroneousFields.timestamp).toBe(expectedUTCTime);
+            }
+        }
     });
 });
 
@@ -640,6 +654,192 @@ describe.each([
         expect(erroneousFields.flags.invalid).toBe(expectedFlags.invalid);
         expect(erroneousFields.FBMGuest.lastname).toEqual(expectedFBMGuestname); // Ensure FBMGuest name is set correctly
     });
+});
+
+describe.each([
+    {
+        name: 'valid date string',
+        date: '2023-10-01T12:00:00Z',
+        expected: '2023-10-01T12:00:00Z'
+    },
+    {
+        name: 'valid date object',
+        date: new Date('2023-10-01T12:00:00Z'),
+        expected: '2023-10-01T12:00:00Z'
+    },
+    {
+        name: 'valid date string with timezone',
+        date: '2023-10-01T12:00:00+02:00',
+        expected: '2023-10-01T10:00:00Z' // Adjusted to UTC
+    },
+    {
+        name: 'valid date object with + timezone',
+        date: new Date('2023-10-01T12:00:00+02:00'),
+        expected: '2023-10-01T10:00:00Z' // Adjusted to UTC
+    },
+    {
+        name: 'valid date object with - timezone',
+        date: new Date('2023-10-01T12:00:00-02:00'),
+        expected: '2023-10-01T14:00:00Z' // Adjusted to UTC
+    },
+    {
+        name: 'valid date string without time, assumes input was from local timezone',
+        date: '2023-10-01',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'date object without specified time takes on midnight at UTC timezone',
+        date: new Date('2023-10-01'),
+        expected: '2023-10-01T00:00:00Z' // Adjusted to UTC
+    },
+    {
+        name: 'valid date string with milliseconds',
+        date: '2023-10-01T12:00:00.123Z',
+        expected: '2023-10-01T12:00:00Z'
+    },
+    {
+        name: 'valid date object with milliseconds',
+        date: new Date('2023-10-01T12:00:00.123Z'),
+        expected: '2023-10-01T12:00:00Z'
+    },
+    {
+        name: 'null date',
+        date: null,
+        expected: undefined
+    },
+    {
+        name: 'invalid date string',
+        date: 'invalid-date',
+        expected: undefined
+    },
+    {
+        name: 'empty string',
+        date: '',
+        expected: undefined
+    },
+    {
+        name: 'whitespace string',
+        date: '   ',
+        expected: undefined
+    },
+    {
+        name: 'date in the past',
+        date: '2000-01-01T00:00:00Z',
+        expected: '2000-01-01T00:00:00Z'
+    },
+    {
+        name: 'date in the future',
+        date: '3023-01-01T00:00:00Z',
+        expected: '3023-01-01T00:00:00Z'
+    },
+    {
+        name: 'date object with invalid time',
+        date: new Date('invalid-date'),
+        expected: undefined
+    },
+    {
+        name: 'string with space instead of T',
+        date: '2023-10-01 12:00:00Z',
+        expected: '2023-10-01T12:00:00Z'
+    },
+    {
+        name: 'valid date string with slashes',
+        date: '10/01/2023 12:00:00',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string with underscores',
+        date: '10_01_2023 12:00:00',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format',
+        date: '10-01-2023 12:00:00',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format without time',
+        date: '10-01-2023',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'valid date string with mixed whitespace and slashes',
+        date: ' 10 / 01 / 2023 12 : 00 : 00 ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string with mixed whitespace and underscores',
+        date: ' 10 _ 01 _ 2023 12 : 00 : 00 ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with mixed whitespace',
+        date: ' 10 - 01 - 2023 12 : 00 : 00 ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with leading/trailing whitespace',
+        date: '   10-01-2023 12:00:00   ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with only date',
+        date: '10-01-2023',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'valid date string in MM/DD/YYYY format',
+        date: '10/01/2023',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'valid date string in MM/DD/YYYY format with time',
+        date: '10/01/2023 12:00:00',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM/DD/YYYY format with leading/trailing whitespace',
+        date: '   10/01/2023 12:00:00   ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM/DD/YYYY format with only date',
+        date: '10/01/2023',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with underscores',
+        date: '10_01_2023',
+        expected: '2023-10-01T00:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with underscores and time',
+        date: '10_01_2023 12:00:00',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with underscores and leading/trailing whitespace',
+        date: '   10_01_2023 12:00:00   ',
+        expected: '2023-10-01T12:00:00'
+    },
+    {
+        name: 'valid date string in MM-DD-YYYY format with underscores and only date',
+        date: '10_01_2023',
+        expected: '2023-10-01T00:00:00'
+    }
+])('toISOFormat - $name', ({ date, expected }) => {
+    it('returns the correct ISO format or undefined', () => {
+        //need to convert expected to local timezone as everything runs on utc
+        if (expected === undefined) {
+            expect(toISOFormat(date)).toBeUndefined();
+            return;
+        }
+        const expectedDate = new Date(expected);
+        // // Convert expected date to UTC to match the function's output
+        // const expectedUTC = new Date(expectedDate.getTime() - expectedDate.getTimezoneOffset() * 60000);
+        expect(toISOFormat(date)).toBe(expectedDate.toISOString().slice(0, 19) + 'Z'); // Slice to remove milliseconds
+    });
+
 });
 
 describe.each([

--- a/server/src/intake_forms/custom_types.ts
+++ b/server/src/intake_forms/custom_types.ts
@@ -102,12 +102,22 @@ export const requiredFields = [
 /**
  * @fields_invalid is a set of field names that are invalid, basically means the form messed up
  * @FBMGuest will have '\0' for keys which are required but not present
+ * @timestamp this is the uid! The stored time value in milliseconds since midnight, January 1, 1970 UTC of when form was submitted.
+ * @flags
+ *  - duplicate: indicates if the client is a duplicate
+ * - severeAllergy: indicates if the client has an allergy
+ * - timestamp_missing: indicates if the timestamp is valid, meaning an injection may have occured
+ * - tenPlus: indicates if the client has more than 10 members in the household
+ * - invalid: indicates if the client has invalid fields
+ * - erroneous: indicates if the client has erroneous fields
+ * - hohInMembers: indicates if the client has household members
  * @fields_erroneous_n_description is a map of field name to description of the error, 
  *     could be empty or more than one this may have unrequired fields, 
  *     but only fields that have data. Perhaps have volunteers decide to discard invalid fields
  *     note: description is for developer, will be subject to change
  */
 export type Erroneous = {
+    timestamp?: number //it is the timestamp of the guest submission, ensures we dont copy over the same data and put it onto our server
     FBMGuest: FBMGuest;
     fields_invalid: Set<string>;
     fields_erroneous_n_description: Map<string, string>;

--- a/server/src/intake_forms/flagger.ts
+++ b/server/src/intake_forms/flagger.ts
@@ -96,6 +96,7 @@ export function _invalidChecker(client: Client, inputErroneousFields: Erroneous)
 /**
  * Checks if the timestamp is valid.
  * A timestamp is invalid if it is null, empty, whitespace, not a valid date, or is in the future.
+ * also adds timestamp to the timestamp field in erroneousFields object
  * @param timestamp - The timestamp to be checked, expected in the format 'MM/DD/YYYY HH:mm:ss'.
  * @param inputErroneousFields - The current erroneous fields to be updated.
  * @returns The updated erroneous fields.
@@ -117,6 +118,9 @@ export function isValidTimestamp(timestamp: string | null | undefined, inputErro
             erroneousFields.flags['invalid'] = true;
             erroneousFields.fields_invalid.add('Timestamp');
             erroneousFields.fields_erroneous_n_description.set('Timestamp', 'Invalid: Timestamp is in the future.');
+        }
+        else {
+            erroneousFields.timestamp = date.getTime(); // Convert to ISO format for FBM
         }
     }
     //dont add timestamp to fbm
@@ -193,21 +197,12 @@ export function isValidLastName(lastName: string | null | undefined, inputErrone
 export function isValidDateOfBirth(dob: string | null | undefined, inputErroneousFields: Erroneous): Erroneous {
     const erroneousFields = copyErroneous(inputErroneousFields);
     const initialdob = dob;
-    //just in case
-    if (dob && /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(dob)) {
-        // Convert 'YYYY-MM-DD HH:mm:ss' to 'YYYY-MM-DDTHH:mm:ss'
-        dob = dob.replace(' ', 'T');
-    }
 
-    //now check formatting
-    if (dob && /^\d{4}-\d{2}-\d{2}$/.test(dob)) {
-        // Convert 'YYYY-MM-DD' to 'YYYY-MM-DDTHH:mm:ss'
-        dob = dob + 'T00:00:00'; // Add time part to make it a valid date string
-    }
+    dob = toISOFormat(dob); // Convert to ISO format, which is 'YYYY-MM-DDTHH:mm:ss' for FBM
 
     //now all formating must conform to the structure of 'YYYY-MM-DDTHH:mm:ss'
 
-    if (!dob || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(dob)) {
+    if (!dob || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(dob)) {
         erroneousFields.flags['invalid'] = true;
         erroneousFields.fields_invalid.add('dob');
         erroneousFields.fields_erroneous_n_description.set('dob', 'Invalid: dob is in the wrong format.');
@@ -244,6 +239,71 @@ export function isValidDateOfBirth(dob: string | null | undefined, inputErroneou
     }
 
     return erroneousFields;
+}
+
+/**
+ * Converts any time into a format of 'YYYY-MM-DDTHH:mm:ssZ'.
+ * it will be in UTC time
+ * if inputed date is a date object then will create a new date object in UTC time
+ * if inputed date is a string then will convert it to a date object in UTC time unless a Z trails it
+ * @param date - a string of a potential date to be converted
+ * @returns The formatted date string in ISO format. Or if not possible undefined. UTC
+ */
+export function toISOFormat(date: string | Date | null | undefined): string | undefined {
+    if (typeof date === 'string') {
+        //trim it
+        date = date.trim();
+        if (!date || date === '') {
+            return undefined; // Return undefined if the date is empty
+        }
+        //convert / and _ to - in case the date is different
+        date = date.replace(/[/_]/g, '-'); // Replace '/' and '_' with '-' to conform to ISO format
+        //get rid of white spaces surrounding dashes
+        date = date.replace(/(\s*-\s*)/g, '-'); // Remove whitespace around dashes
+        //remove white spaces around colons
+        date = date.replace(/(\s*:\s*)/g, ':'); // Remove whitespace around colons
+
+        //should all not have this if already in ISO format
+        //convert all white spaces to T
+        date = date.replace(/\s+/g, 'T'); // Replace all whitespace with 'T' to conform to ISO format
+
+
+        // Check if the date is in 'MM-DD-YYYY*' format then convert it to 'YYYY-MM-DD*'
+        date = date.replace(/^(\d{1,2})-(\d{1,2})-(\d{4})(.*)$/, '$3-$1-$2$4'); // Convert 'MM-DD-YYYY' to 'YYYY-MM-DD'
+
+        //check if the date is in a valid iso format
+        if (!/^\d{4}-\d{2}-\d{2}(.*)$/.test(date)) {
+            return undefined; // Return undefined if the date is not in a valid ISO format
+        }
+
+        //append 'T00:00:00' if the time is not specified
+        if (!date.includes('T')) {
+            date += 'T00:00:00'; // Append 'T00:00:00' if time is not specified
+        }
+        //if date indludes a timezone, then transform date into a time object
+        //Z is standard for UTC
+        //also + and - are used for timezones
+        if (!date.includes('Z') || date.includes('+') || date.includes('-')) {
+            //if the date is in UTC format, then need to use UTC method
+            const utcDate = new Date(date);
+            date = utcDate.toISOString().split('.')[0] + 'Z'; // Convert to ISO format 'YYYY-MM-DDTHH:mm:ss'
+        } else {
+            //it must be now in iso format so just return it
+            //date=date
+
+        }
+
+
+    } else {
+        if (!date || isNaN(date.getTime())) {
+            return undefined; // Return undefined if the date is invalid
+        }
+    }
+    if (typeof date === 'string') {
+        return date.slice(0, 20); // Return the first 19 characters to get 'YYYY-MM-DDTHH:mm:ss'
+    }
+    // Convert to ISO format 'YYYY-MM-DDTHH:mm:ss'
+    return date.toISOString().split('.')[0] + 'Z';
 }
 
 /**


### PR DESCRIPTION
This is the pull request for the related issue. Specifically added timestamp and related tests for the architecture. and switched to it being stored as a number. Also made the date of birth helper method more robust. Which may seem like extra work, but I suspect that this new helper function will be reused for all datetime inputs.